### PR TITLE
Address possible issue with skewed timestamps in system log after (re)boot with power loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ __pycache__
 *.pyo
 create-test-env
 run-test-exporter-onetime
+run-test-exporter-timeshifted-onetime
 tests/*.log.state
+tests/default-timeshifted.log
 loki-exporter/

--- a/Makefile
+++ b/Makefile
@@ -175,9 +175,12 @@ test: run-test-exporter-onetime run-test-exporter-timeshifted-onetime | .venv re
 compare-logs: | results
 	cat tests/default.log | cut -c 43- | sort >results/messages.original
 	cat results/resurrected.log | cut -c 17- | sort >results/messages.resurrected
-	wc -l results/messages.original results/messages.resurrected
-	diff -u results/messages.original results/messages.resurrected ||:
-	test $$(diff -u results/messages.original results/messages.resurrected | grep -- " (MOCK)$$" | wc -l) -eq 3
+	cat results/resurrected-timeshifted.log | cut -c 17- | sort >results/messages.resurrected-timeshifted
+	for target in messages.resurrected messages.resurrected-timeshifted; do \
+		wc -l results/messages.original results/$${target} ; \
+		diff -u results/messages.original results/$${target} ||: ; \
+		test $$(diff -u results/messages.original results/$${target} | grep -- " (MOCK)$$" | wc -l) -eq 3 ; \
+	done
 
 .PHONY: save-logs
 save-logs: | results

--- a/loki_exporter.sh
+++ b/loki_exporter.sh
@@ -17,11 +17,11 @@ DATETIME_STR_FORMAT="%a %b %d %H:%M:%S %Y"
 OS=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 if [ "${AUTOTEST-0}" -eq 1 ]; then
-    _CURL_BULK_CMD=(curl --no-progress-meter -fv -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
-    _CURL_CMD=(curl --no-progress-meter -fv -H "Content-type: application/json" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
+    _CURL_BULK_CMD=(curl --no-progress-meter -fv -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Connection: close")
+    _CURL_CMD=(curl --no-progress-meter -fv -H "Content-Type: application/json" -H "Connection: close")
 else
-    _CURL_BULK_CMD=(curl -fsS -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
-    _CURL_CMD=(curl -fsS -H "Content-type: application/json" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
+    _CURL_BULK_CMD=(curl -fsS -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Authorization: Basic ${LOKI_AUTH_HEADER}" -H "Connection: close")
+    _CURL_CMD=(curl -fsS -H "Content-Type: application/json" -H "Authorization: Basic ${LOKI_AUTH_HEADER}" -H "Connection: close")
 fi
 
 _setup() {

--- a/loki_exporter.sh
+++ b/loki_exporter.sh
@@ -17,11 +17,11 @@ DATETIME_STR_FORMAT="%a %b %d %H:%M:%S %Y"
 OS=$(uname -s | tr "[:upper:]" "[:lower:]")
 
 if [ "${AUTOTEST-0}" -eq 1 ]; then
-    _CURL_BULK_CMD=(curl --no-progress-meter -fv -X POST -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
-    _CURL_CMD=(curl -fv -X POST -H "Content-type: application/json" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
+    _CURL_BULK_CMD=(curl --no-progress-meter -fv -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
+    _CURL_CMD=(curl --no-progress-meter -fv -H "Content-type: application/json" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
 else
-    _CURL_BULK_CMD=(curl -fsS -X POST -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
-    _CURL_CMD=(curl -fsS -X POST -H "Content-type: application/json" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
+    _CURL_BULK_CMD=(curl -fsS -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
+    _CURL_CMD=(curl -fsS -H "Content-type: application/json" -H "Authorization: Basic ${LOKI_AUTH_HEADER}")
 fi
 
 _setup() {

--- a/loki_exporter.sh
+++ b/loki_exporter.sh
@@ -55,12 +55,13 @@ _do_bulk_post() {
     echo "${post_body}" | gzip >${BULK_DATA}.payload.gz
     rm -f ${BULK_DATA}
 
-    if curl -fs -X POST -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Authorization: Basic ${LOKI_AUTH_HEADER}" --data-binary "@${BULK_DATA}.payload.gz" "${LOKI_PUSH_URL}"; then
+    if curl --no-progress-meter -fi -X POST -H "Content-Type: application/json" -H "Content-Encoding: gzip" -H "Authorization: Basic ${LOKI_AUTH_HEADER}" --data-binary "@${BULK_DATA}.payload.gz" "${LOKI_PUSH_URL}" >"${BULK_DATA}.payload.gz-response" 2>&1; then
         if [ "${AUTOTEST-0}" -eq 1 ]; then
             mkdir -p results
             cp ${BULK_DATA}.payload.gz results/
+            cp ${BULK_DATA}.payload.gz-response results/
         fi
-        rm -f ${BULK_DATA}.payload.gz
+        rm -f ${BULK_DATA}.payload.gz ${BULK_DATA}.payload.gz-response
     else
         echo "BULK POST FAILED: leaving ${BULK_DATA}.payload.gz for now"
     fi

--- a/tests/create_timeshifted_log.py
+++ b/tests/create_timeshifted_log.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Helper script to create log with timestamp skew emulation
+"""
+
+import sys
+import random
+from logread import MockLogRead
+
+
+def main():
+    """
+    Entrypoint
+    """
+    mlr = MockLogRead()
+    mlr.parse_args()
+    mlr.load_lines()
+
+    num_lines = len(mlr.lines)
+    sync_from_line = random.randrange(
+        (num_lines // 3) * 2, (num_lines // 3) * 2 + (num_lines // 3) // 2
+    )
+    shift_back = (180 * 86400) + (random.randrange(1, 30) * 86400)
+
+    # print(f"loaded {num_lines} lines; making {sync_from_line} the 1st one with synced time")
+
+    for nl, line in enumerate(mlr.lines):
+        if nl < sync_from_line:
+            msg = mlr.get_msg_from_line(line)
+            ts = mlr.get_ts_existing(line)
+            ts -= shift_back
+            tstr = mlr.datetime_str_from_ts(ts)
+            print(f"{tstr} [{ts:.03f}] {msg}")
+            continue
+        print(line)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/logread.py
+++ b/tests/logread.py
@@ -21,6 +21,7 @@ class MockLogRead:
         self.lines = []
         self.args = None
         self.ts_first_line = None
+        self.ts_last_line = None
         self.ts_start_from = None
         self.ts_apply_delta = None
 
@@ -142,6 +143,7 @@ class MockLogRead:
             self.lines = [line.rstrip() for line in file.readlines()]
 
         self.ts_first_line = self.get_adjusted_ts(self.lines[0])
+        self.ts_last_line = self.get_adjusted_ts(self.lines[-1])
         state_file = self.args.log_file + ".state"
 
         if os.path.isfile(state_file):
@@ -152,7 +154,8 @@ class MockLogRead:
             with open(state_file, "w", encoding="utf-8") as file:
                 file.write(f"{self.ts_start_from.timestamp()}\n")
 
-        self.ts_apply_delta = self.ts_start_from.timestamp() - self.ts_first_line
+        # for timeshift tests we assume that last line always contains synchronized timestamp
+        self.ts_apply_delta = self.ts_start_from.timestamp() - self.ts_last_line
 
     def print_line(self, line: str):
         """

--- a/tests/test_loki.py
+++ b/tests/test_loki.py
@@ -125,7 +125,7 @@ def test_line_count_timeshifted():
                     l.append({"ts": ts, "msg": msg})
 
     l = sorted(l, key=lambda d: d["ts"])
-    with open("results/resurrected.log", "w", encoding="utf-8") as file:
+    with open("results/resurrected-timeshifted.log", "w", encoding="utf-8") as file:
         for entry in l:
             file.write(f"{entry['ts']:.3f}: {entry['msg']}\n")
 

--- a/tests/test_loki.py
+++ b/tests/test_loki.py
@@ -3,17 +3,15 @@ Base tests for loki_exporter
 """
 
 from datetime import datetime, timedelta, timezone
+from platform import node as gethostname
+import pytest
 from client import BASE_URL, query_labels, query_range
-
-# from client import flush
 
 
 def test_labels():
     """
     Check available labels and match with expectation
     """
-    # assert flush(BASE_URL) is True, "flush succeeded"
-
     response = query_labels(BASE_URL)
 
     assert "status" in response.keys()
@@ -33,16 +31,80 @@ def test_line_count():
     """
     Verify that loki returns expected number of processed lines
     """
-
-    # assert flush(BASE_URL) is True, "flush succeeded"
-
     current_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     start_time = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
     )
 
+    hostname = gethostname()
     response = query_range(
-        BASE_URL, '{job="openwrt_loki_exporter"}', start_time, current_time, limit=1000
+        BASE_URL,
+        f'{{job="openwrt_loki_exporter", host="{hostname}"}}',
+        start_time,
+        current_time,
+        limit=1000,
+    )
+
+    assert "status" in response.keys()
+    assert response.get("status") == "success"
+
+    assert "data" in response.keys()
+    data = response.get("data")
+    assert isinstance(data, dict)
+
+    assert "result" in data.keys()
+    result = data.get("result")
+    assert isinstance(result, list)
+    assert len(result) == 1
+
+    l = []
+    total_entries = 0
+    for h in result:
+        for k, v in h.items():
+            if k == "values":
+                total_entries += len(v)
+                for entry in v:
+                    ts = int(entry[0]) / 10**9
+                    msg = entry[1]
+                    l.append({"ts": ts, "msg": msg})
+
+    l = sorted(l, key=lambda d: d["ts"])
+    with open("results/resurrected.log", "w", encoding="utf-8") as file:
+        for entry in l:
+            file.write(f"{entry['ts']:.3f}: {entry['msg']}\n")
+
+    assert total_entries == 485
+
+    assert "stats" in data.keys()
+    stats = data.get("stats")
+    assert isinstance(stats, dict)
+
+    assert "summary" in stats.keys()
+    assert (
+        stats.get("summary", {}).get("totalLinesProcessed") == 485
+    ), "count of total processed lines"
+
+
+@pytest.mark.skip(
+    reason="TODO: not yet; https://github.com/defanator/openwrt-loki-exporter/issues/5"
+)
+def test_line_count_timeshifted():
+    """
+    Verify that loki returns expected number of processed lines
+    from log with skewed timestamps
+    """
+    current_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    start_time = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    hostname = gethostname()
+    response = query_range(
+        BASE_URL,
+        f'{{job="openwrt_loki_exporter", host="{hostname}.timeshifted"}}',
+        start_time,
+        current_time,
+        limit=1000,
     )
 
     assert "status" in response.keys()

--- a/tests/test_loki.py
+++ b/tests/test_loki.py
@@ -4,7 +4,6 @@ Base tests for loki_exporter
 
 from datetime import datetime, timedelta, timezone
 from platform import node as gethostname
-import pytest
 from client import BASE_URL, query_labels, query_range
 
 
@@ -36,10 +35,9 @@ def test_line_count():
         "%Y-%m-%dT%H:%M:%SZ"
     )
 
-    hostname = gethostname()
     response = query_range(
         BASE_URL,
-        f'{{job="openwrt_loki_exporter", host="{hostname}"}}',
+        f'{{job="openwrt_loki_exporter", host="{gethostname()}"}}',
         start_time,
         current_time,
         limit=1000,
@@ -85,9 +83,6 @@ def test_line_count():
     ), "count of total processed lines"
 
 
-@pytest.mark.skip(
-    reason="TODO: not yet; https://github.com/defanator/openwrt-loki-exporter/issues/5"
-)
 def test_line_count_timeshifted():
     """
     Verify that loki returns expected number of processed lines
@@ -98,10 +93,9 @@ def test_line_count_timeshifted():
         "%Y-%m-%dT%H:%M:%SZ"
     )
 
-    hostname = gethostname()
     response = query_range(
         BASE_URL,
-        f'{{job="openwrt_loki_exporter", host="{hostname}.timeshifted"}}',
+        f'{{job="openwrt_loki_exporter", host="{gethostname()}.timeshifted"}}',
         start_time,
         current_time,
         limit=1000,


### PR DESCRIPTION
Proposed changes include additional step between collecting and submitting system log after router reboot: checking the log for possible "jump" in timestamps, which may occur in cases when a router was booted after power loss and hardware clock was unsynchronized until the NTP comes into play.

Having part of log lines marked with older timestamps makes it impossible to put such entries to loki (it accepts entries no older than an hour or so by default).

New logic involves remapping timestamps for unsynchronized lines backwards from 1st line with the very first timestamp after clock was synchronized (see tests for more details).

Intended to close #5.