### PR TITLE
Introduce extra knobs to control on-boot behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ run-test-exporter-onetime: create-test-env ## Run one-time cycle of mocking logr
 	LOKI_AUTH_HEADER="none" \
 	MAX_FOLLOW_CYCLES=3 \
 	AUTOTEST=1 \
+	START_DELAY_ON_BOOT=3 \
 	/bin/bash -u loki_exporter.sh
 	touch $@
 
@@ -164,6 +165,7 @@ run-test-exporter-timeshifted-onetime: tests/default-timeshifted.log create-test
 	LOKI_AUTH_HEADER="none" \
 	MAX_FOLLOW_CYCLES=3 \
 	AUTOTEST=1 \
+	START_DELAY_ON_BOOT=3 \
 	/bin/bash -u loki_exporter.sh
 	touch $@
 

--- a/loki_exporter.conf
+++ b/loki_exporter.conf
@@ -2,4 +2,6 @@
 config loki_exporter
 	option loki_push_url 'http://127.0.0.1/loki/api/v1/push'
 	option loki_auth_header 'ADDME'
+	option start_delay_on_boot '120'
+	option skewed_timestamps_delta_threshold '3600'
 

--- a/loki_exporter.init
+++ b/loki_exporter.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-# delayed start to ensure network and NTP sync are done
+# delayed start to ensure network and NTP services go first
 START=99
 # stop before stopping network
 STOP=89
@@ -13,10 +13,12 @@ BOOT=0
 start_service() {
 	local loki_push_url=$(uci -q get loki_exporter.@loki_exporter[0].loki_push_url)
 	local loki_auth_header=$(uci -q get loki_exporter.@loki_exporter[0].loki_auth_header)
+	local start_delay_on_boot=$(uci -q get loki_exporter.@loki_exporter[0].start_delay_on_boot)
+	local skewed_timestamps_delta_threshold=$(uci -q get loki_exporter.@loki_exporter[0].skewed_timestamps_delta_threshold)
 
 	procd_open_instance
 	procd_set_param command "$PROG"
-	procd_set_param env BOOT="${BOOT}" LOGREAD="/sbin/logread" LOKI_PUSH_URL="${loki_push_url}" LOKI_AUTH_HEADER="${loki_auth_header}"
+	procd_set_param env BOOT="${BOOT}" LOGREAD="/sbin/logread" LOKI_PUSH_URL="${loki_push_url}" LOKI_AUTH_HEADER="${loki_auth_header}" START_DELAY_ON_BOOT="${start_delay_on_boot}" SKEWED_TIMESTAMP_DELTA_THRESHOLD="${skewed_timestamps_delta_threshold}"
 	procd_set_param stderr 1
 	procd_close_instance
 }

--- a/loki_exporter.sh
+++ b/loki_exporter.sh
@@ -112,8 +112,9 @@ _do_bulk_post() {
 _check_for_skewed_timestamp() {
     _log_file="$1"
 
-    # maximum threshold for comparing timestamps between 2 subsequent log lines (ns)
-    delta_threshold=86400000000000
+    # maximum threshold for comparing timestamps between 2 subsequent log lines (s, ns)
+    delta_threshold_seconds="${SKEWED_TIMESTAMP_DELTA_THRESHOLD-3600}"
+    delta_threshold=$((delta_threshold_seconds * 10**9))
 
     # incremental step for substituting timestamps of unsynchronized log lines (ns)
     step=25000000
@@ -249,6 +250,13 @@ _main_loop() {
         MIN_TIMESTAMP="${ts_ns}"
     done <"${PIPE_NAME}"
 }
+
+if [ "${BOOT}" -eq 1 ]; then
+    if [ "${START_DELAY_ON_BOOT-0}" -gt 0 ]; then
+        echo "sleeping ${START_DELAY_ON_BOOT-0} seconds before proceeding" >&2
+        sleep "${START_DELAY_ON_BOOT-0}"
+    fi
+fi
 
 _setup
 


### PR DESCRIPTION
In particular:

1. The `start_delay_on_boot` config option sets period (in seconds) of extra delay before reading and submitting initial portion of system log after reboot to make sure network is up and time was synchronized via NTP (default is 2 minutes).

2. The `skewed_timestamps_delta_threshold` config option allows to redefine maximum delta threshold (in seconds) between two consecutive timestamps in order to decide that there was a gap due to stale clock. Default is now 1 hour, reduced from previously set 24 hours.

This is a follow-up update addressing initial issue described in #5.