### PR TITLE
CI: run tests with ash / busybox in addition to bash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,14 +65,6 @@ jobs:
           sudo busybox --install bin/
       - name: Create virtualenv
         run: make venv
-      - name: Run formatters
-        if: ${{ always() }}
-        run: |
-          make fmt
-          git diff
-      - name: Run linters
-        if: ${{ always() }}
-        run: make lint
       - name: Run tests
         if: ${{ always() }}
         run: TEST_SHELL=$(pwd)/bin/ash make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,3 +45,47 @@ jobs:
           name: results
           path: results/**
           retention-days: 7
+
+  test-busybox:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Show environment
+        run: make show-env
+      - name: Install busybox
+        run: |
+          sudo apt-get update && sudo apt-get install -y busybox
+          mkdir -p bin
+          sudo busybox --install bin/
+      - name: Create virtualenv
+        run: make venv
+      - name: Run formatters
+        if: ${{ always() }}
+        run: |
+          make fmt
+          git diff
+      - name: Run linters
+        if: ${{ always() }}
+        run: make lint
+      - name: Run tests
+        if: ${{ always() }}
+        run: TEST_SHELL=$(pwd)/bin/ash make test
+      - name: Compare logs
+        if: ${{ always() }}
+        run: make compare-logs
+      - name: Save container logs
+        if: ${{ always() }}
+        run: make save-logs
+      - name: Save CI artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-busybox
+          path: results/**
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,6 @@ run-test-exporter: wait-for-loki ## Run exporter with mocking logread (BOOT=0)
 	HOSTNAME="$(shell hostname)" \
 	LOKI_PUSH_URL="http://127.0.0.1:3100/loki/api/v1/push" \
 	LOKI_AUTH_HEADER="none" \
-	LC_ALL=C \
 	$(TEST_SHELL) -u loki_exporter.sh
 
 .PHONY: run-test-exporter-boot
@@ -150,7 +149,6 @@ run-test-exporter-boot: test-env ## Run exporter with mocking logread (BOOT=1)
 	HOSTNAME="$(shell hostname)" \
 	LOKI_PUSH_URL="http://127.0.0.1:3100/loki/api/v1/push" \
 	LOKI_AUTH_HEADER="none" \
-	LC_ALL=C \
 	$(TEST_SHELL) -u loki_exporter.sh
 
 tests/default-timeshifted.log: tests/default.log
@@ -165,7 +163,6 @@ run-test-exporter-onetime: wait-for-loki ## Run one-time cycle of mocking logrea
 	MAX_FOLLOW_CYCLES=3 \
 	AUTOTEST=1 \
 	START_DELAY_ON_BOOT=3 \
-	LC_ALL=C \
 	$(TEST_SHELL) -u loki_exporter.sh
 	touch $@
 
@@ -178,7 +175,6 @@ run-test-exporter-timeshifted-onetime: tests/default-timeshifted.log wait-for-lo
 	MAX_FOLLOW_CYCLES=3 \
 	AUTOTEST=1 \
 	START_DELAY_ON_BOOT=3 \
-	LC_ALL=C \
 	$(TEST_SHELL) -u loki_exporter.sh
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ VERSION := $(shell git describe --tags --always --match='v[0-9]*' | cut -d '-' -
 RELEASE := $(shell git describe --tags --always --match='v[0-9]*' --long | cut -d '-' -f 2)
 BUILD   := $(shell git describe --tags --long --always --dirty)-$(DATE)-$(GITHUB_RUN_ID)
 
+TEST_SHELL ?= /bin/bash
+
 SHOW_ENV_VARS = \
 	VERSION \
 	RELEASE \
@@ -50,7 +52,8 @@ SHOW_ENV_VARS = \
 	OPENWRT_ARCH \
 	OPENWRT_TARGET \
 	OPENWRT_SUBTARGET \
-	OPENWRT_VERMAGIC
+	OPENWRT_VERMAGIC \
+	TEST_SHELL
 
 help: ## Show help message (list targets)
 	@awk 'BEGIN {FS = ":.*##"; printf "\nTargets:\n"} /^[$$()% 0-9a-zA-Z_-]+:.*?##/ {printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2}' $(SELF)
@@ -131,7 +134,7 @@ run-test-exporter: create-test-env ## Run exporter with mocking logread (BOOT=0)
 	HOSTNAME="$(shell hostname)" \
 	LOKI_PUSH_URL="http://127.0.0.1:3100/loki/api/v1/push" \
 	LOKI_AUTH_HEADER="none" \
-	/bin/bash -u loki_exporter.sh
+	$(TEST_SHELL) -u loki_exporter.sh
 
 .PHONY: run-test-exporter-boot
 run-test-exporter-boot: test-env ## Run exporter with mocking logread (BOOT=1)
@@ -140,7 +143,7 @@ run-test-exporter-boot: test-env ## Run exporter with mocking logread (BOOT=1)
 	HOSTNAME="$(shell hostname)" \
 	LOKI_PUSH_URL="http://127.0.0.1:3100/loki/api/v1/push" \
 	LOKI_AUTH_HEADER="none" \
-	/bin/bash -u loki_exporter.sh
+	$(TEST_SHELL) -u loki_exporter.sh
 
 tests/default-timeshifted.log: tests/default.log
 	$(TOPDIR)/tests/create_timeshifted_log.py >$@
@@ -154,7 +157,7 @@ run-test-exporter-onetime: create-test-env ## Run one-time cycle of mocking logr
 	MAX_FOLLOW_CYCLES=3 \
 	AUTOTEST=1 \
 	START_DELAY_ON_BOOT=3 \
-	/bin/bash -u loki_exporter.sh
+	$(TEST_SHELL) -u loki_exporter.sh
 	touch $@
 
 run-test-exporter-timeshifted-onetime: tests/default-timeshifted.log create-test-env ## Run one-time cycle of mocking logread + exporter (BOOT=1 with time unsync emulation)
@@ -166,7 +169,7 @@ run-test-exporter-timeshifted-onetime: tests/default-timeshifted.log create-test
 	MAX_FOLLOW_CYCLES=3 \
 	AUTOTEST=1 \
 	START_DELAY_ON_BOOT=3 \
-	/bin/bash -u loki_exporter.sh
+	$(TEST_SHELL) -u loki_exporter.sh
 	touch $@
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,16 @@ lint: | .venv ## Run linters (shellcheck for .sh, pylint for .py)
 fmt: | .venv ## Run formatters
 	$(TOPDIR)/.venv/bin/python3 -m black tests/*.py
 
-CHECK_ENV_TIMEOUT ?= 30
-create-test-env: ## Spin up testing compose environment with Loki and Grafana
+create-test-env-full: ## Spin up testing compose environment with Loki and Grafana
 	docker compose -f tests/compose.yml up -d
+
+create-test-env: ## Spin up testing compose environment with Loki
+	docker compose -f tests/compose.yml up -d loki
+	touch $@
+
+CHECK_ENV_TIMEOUT ?= 30
+.PHONY: wait-for-loki
+wait-for-loki: create-test-env
 	@{ \
 	rc=0 ; \
 	wait_timeout=$(CHECK_ENV_TIMEOUT) ; \
@@ -120,20 +127,20 @@ create-test-env: ## Spin up testing compose environment with Loki and Grafana
 	fi ; \
 	exit $$rc ; \
 	}
-	touch $@
 
 .PHONY: delete-test-env
-delete-test-env: ## Stop and remove testing compose environment with Loki and Grafana
+delete-test-env: ## Stop and remove testing compose environment
 	docker compose -f tests/compose.yml down
 	rm -f create-test-env
 
 .PHONY: run-test-exporter
-run-test-exporter: create-test-env ## Run exporter with mocking logread (BOOT=0)
+run-test-exporter: wait-for-loki ## Run exporter with mocking logread (BOOT=0)
 	LOGREAD="./tests/logread.py" \
 	BOOT=0 \
 	HOSTNAME="$(shell hostname)" \
 	LOKI_PUSH_URL="http://127.0.0.1:3100/loki/api/v1/push" \
 	LOKI_AUTH_HEADER="none" \
+	LC_ALL=C \
 	$(TEST_SHELL) -u loki_exporter.sh
 
 .PHONY: run-test-exporter-boot
@@ -143,12 +150,13 @@ run-test-exporter-boot: test-env ## Run exporter with mocking logread (BOOT=1)
 	HOSTNAME="$(shell hostname)" \
 	LOKI_PUSH_URL="http://127.0.0.1:3100/loki/api/v1/push" \
 	LOKI_AUTH_HEADER="none" \
+	LC_ALL=C \
 	$(TEST_SHELL) -u loki_exporter.sh
 
 tests/default-timeshifted.log: tests/default.log
 	$(TOPDIR)/tests/create_timeshifted_log.py >$@
 
-run-test-exporter-onetime: create-test-env ## Run one-time cycle of mocking logread + exporter (BOOT=1)
+run-test-exporter-onetime: wait-for-loki ## Run one-time cycle of mocking logread + exporter (BOOT=1)
 	LOGREAD="./tests/logread.py" \
 	BOOT=1 \
 	HOSTNAME="$(shell hostname)" \
@@ -157,10 +165,11 @@ run-test-exporter-onetime: create-test-env ## Run one-time cycle of mocking logr
 	MAX_FOLLOW_CYCLES=3 \
 	AUTOTEST=1 \
 	START_DELAY_ON_BOOT=3 \
+	LC_ALL=C \
 	$(TEST_SHELL) -u loki_exporter.sh
 	touch $@
 
-run-test-exporter-timeshifted-onetime: tests/default-timeshifted.log create-test-env ## Run one-time cycle of mocking logread + exporter (BOOT=1 with time unsync emulation)
+run-test-exporter-timeshifted-onetime: tests/default-timeshifted.log wait-for-loki ## Run one-time cycle of mocking logread + exporter (BOOT=1 with time unsync emulation)
 	LOGREAD="./tests/logread.py --log-file tests/default-timeshifted.log" \
 	BOOT=1 \
 	HOSTNAME="$(shell hostname).timeshifted" \
@@ -169,6 +178,7 @@ run-test-exporter-timeshifted-onetime: tests/default-timeshifted.log create-test
 	MAX_FOLLOW_CYCLES=3 \
 	AUTOTEST=1 \
 	START_DELAY_ON_BOOT=3 \
+	LC_ALL=C \
 	$(TEST_SHELL) -u loki_exporter.sh
 	touch $@
 

--- a/loki_exporter.sh
+++ b/loki_exporter.sh
@@ -4,6 +4,8 @@
 # ^^^ the above line is purely for shellcheck to treat this as a bash-like script
 # (OpenWRT's ash from busybox is kinda similar but there still could be issues)
 
+LC_ALL=C
+
 _TMPDIR="$(mktemp -d -p /tmp loki_exporter.XXXXXX)"
 PIPE_NAME="${_TMPDIR}/loki_exporter.pipe"
 BULK_DATA="${_TMPDIR}/loki_exporter.boot"


### PR DESCRIPTION
As ash is a native shell in OpenWrt, it would be cool to have integrated tests to be running under ash as well (in addition to standard bash).

Closes #12.